### PR TITLE
Preallocate result arrays and apply earlier slicing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ ignore =
 [isort]
 default_section = THIRDPARTY
 known_first_party = sgkit
-known_third_party = bgen_reader,dask,numpy,pytest,xarray
+known_third_party = bgen_reader,dask,numpy,pytest,setuptools,xarray
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup(use_scm_version=True)

--- a/sgkit_bgen/bgen_reader.py
+++ b/sgkit_bgen/bgen_reader.py
@@ -130,10 +130,14 @@ class BgenReader:
                 all_vaddr.extend(vaddr[start_offset:end_offset])
 
         with bgen_file(self.path) as bgen:
-            genotypes = [bgen.read_genotype(vaddr) for vaddr in all_vaddr]
-            all_probs = [genotype["probs"] for genotype in genotypes]
-            d = [_to_dosage(probs) for probs in all_probs]
-            return np.stack(d)[:, idx[1]]
+            res = None
+            for i, vaddr in enumerate(all_vaddr):
+                probs = bgen.read_genotype(vaddr)["probs"][idx[1]]
+                dosage = _to_dosage(probs)
+                if res is None:
+                    res = np.zeros((len(all_vaddr), len(dosage)), dtype=self.dtype)
+                res[i] = dosage
+            return res
 
 
 def _to_dosage(probs: ArrayLike):


### PR DESCRIPTION
This addresses the memory usage issues I saw in https://github.com/pystatgen/sgkit-bgen/issues/9.

To summarize, the memory used when running bgen-reader directly as a part of https://github.com/limix/bgen-reader-py/issues/30#issuecomment-674923428 was fairly minimal.  When running our wrapper around it though I saw memory usage run up to ~10x that.  Pre-allocating result arrays and applying sample slices earlier fixes this to the extent that the memory used is now more like 2-3x that used without the wrapper.

TODO: This also has changes from https://github.com/pystatgen/sgkit-bgen/pull/11 but they're minimal so I left them in until that gets merged and the diff from it goes away.