### PR TITLE
Bgen to zarr (v2)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ numpy
 scipy
 xarray
 zarr
-bgen_reader>=4.0.5
+bgen_reader==4.0.5
 git+https://github.com/pystatgen/sgkit
 git+https://github.com/eric-czech/rechunker.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ scipy
 xarray
 zarr
 bgen_reader==4.0.5
+git+https://github.com/pangeo-data/rechunker
 git+https://github.com/pystatgen/sgkit
-git+https://github.com/eric-czech/rechunker.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ xarray
 zarr
 bgen_reader>=4.0.5
 git+https://github.com/pystatgen/sgkit
+git+https://github.com/eric-czech/rechunker.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ ignore =
 [isort]
 default_section = THIRDPARTY
 known_first_party = sgkit
-known_third_party = bgen_reader,dask,numpy,pytest,setuptools,xarray
+known_third_party = bgen_reader,dask,numpy,pytest,setuptools,xarray,zarr
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0
@@ -70,6 +70,8 @@ ignore_missing_imports = True
 [mypy-bgen_reader.*]
 ignore_missing_imports = True
 [mypy-sgkit.*]
+ignore_missing_imports = True
+[mypy-zarr.*]
 ignore_missing_imports = True
 [mypy-sgkit_bgen.tests.*]
 disallow_untyped_defs = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,3 +79,4 @@ ignore_missing_imports = True
 disallow_untyped_defs = False
 [mypy-sgkit_bgen.*]
 allow_redefinition = True
+warn_unused_ignores = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ ignore =
 [isort]
 default_section = THIRDPARTY
 known_first_party = sgkit
-known_third_party = bgen_reader,dask,numpy,pytest,setuptools,xarray,zarr
+known_third_party = bgen_reader,dask,numpy,pytest,rechunker,setuptools,xarray,zarr
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0
@@ -67,6 +67,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-setuptools.*]
 ignore_missing_imports = True
+[mypy-rechunker.*]
+ignore_missing_imports = True
 [mypy-bgen_reader.*]
 ignore_missing_imports = True
 [mypy-sgkit.*]
@@ -75,3 +77,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-sgkit_bgen.tests.*]
 disallow_untyped_defs = False
+[mypy-sgkit_bgen.*]
+allow_redefinition = True

--- a/sgkit_bgen/__init__.py
+++ b/sgkit_bgen/__init__.py
@@ -1,3 +1,3 @@
-from .bgen_reader import read_bgen, rechunk_from_zarr, rechunk_to_zarr  # noqa: F401
+from .bgen_reader import bgen_to_zarr, read_bgen, rechunk_bgen  # noqa: F401
 
-__all__ = ["read_bgen", "rechunk_from_zarr", "rechunk_to_zarr"]
+__all__ = ["read_bgen", "rechunk_bgen", "bgen_to_zarr"]

--- a/sgkit_bgen/__init__.py
+++ b/sgkit_bgen/__init__.py
@@ -1,3 +1,3 @@
-from .bgen_reader import read_bgen  # noqa: F401
+from .bgen_reader import read_bgen, rechunk_from_zarr, rechunk_to_zarr  # noqa: F401
 
-__all__ = ["read_bgen"]
+__all__ = ["read_bgen", "rechunk_from_zarr", "rechunk_to_zarr"]

--- a/sgkit_bgen/bgen_reader.py
+++ b/sgkit_bgen/bgen_reader.py
@@ -1,16 +1,19 @@
 """BGEN reader implementation (using bgen_reader)"""
 from pathlib import Path
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Hashable, MutableMapping, Optional, Tuple, Union
 
 import dask.array as da
 import dask.dataframe as dd
 import numpy as np
+import xarray as xr
+import zarr
 from bgen_reader._bgen_file import bgen_file
 from bgen_reader._bgen_metafile import bgen_metafile
 from bgen_reader._metafile import create_metafile
 from bgen_reader._reader import infer_metafile_filepath
 from bgen_reader._samples import generate_samples, read_samples_file
 from xarray import Dataset
+from xarray.backends.zarr import ZarrStore
 
 from sgkit import create_genotype_dosage_dataset
 from sgkit.typing import ArrayLike
@@ -37,6 +40,13 @@ VARIANT_FIELDS = [
 ]
 VARIANT_DF_DTYPE = dict([(f[0], f[1]) for f in VARIANT_FIELDS])
 VARIANT_ARRAY_DTYPE = dict([(f[0], f[2]) for f in VARIANT_FIELDS])
+
+GT_DATA_VARS = [
+    "call_genotype_probability",
+    "call_genotype_probability_mask",
+    "call_dosage",
+    "call_dosage_mask",
+]
 
 
 class BgenReader:
@@ -79,15 +89,7 @@ class BgenReader:
 
                 return np.apply_along_axis(split, 1, alleles[:, np.newaxis])
 
-            variant_alleles = variant_arrs["allele_ids"].map_blocks(split_alleles)
-
-            def max_str_len(arr: ArrayLike) -> Any:
-                return arr.map_blocks(
-                    lambda s: np.char.str_len(s.astype(str)), dtype=np.int8
-                ).max()
-
-            max_allele_length = max(max_str_len(variant_alleles).compute())
-            self.variant_alleles = variant_alleles.astype(f"S{max_allele_length}")
+            self.variant_alleles = variant_arrs["allele_ids"].map_blocks(split_alleles)
 
         with bgen_file(self.path) as bgen:
             sample_path = self.path.with_suffix(".sample")
@@ -172,6 +174,7 @@ def read_bgen(
     chunks: Union[str, int, Tuple[int, ...]] = "auto",
     lock: bool = False,
     persist: bool = True,
+    dtype: Any = "float32",
 ) -> Dataset:
     """Read BGEN dataset.
 
@@ -194,23 +197,23 @@ def read_bgen(
         memory, by default True.  This is an important performance
         consideration as the metadata file for this data will
         be read multiple times when False.
+    dtype : Any
+        Genotype probability array data type, by default float32.
 
     Warnings
     --------
     Only bi-allelic, diploid BGEN files are currently supported.
     """
 
-    bgen_reader = BgenReader(path, persist)
+    bgen_reader = BgenReader(path, persist, dtype=dtype)
 
     variant_contig, variant_contig_names = encode_array(bgen_reader.contig.compute())
     variant_contig_names = list(variant_contig_names)
     variant_contig = variant_contig.astype("int16")
-
-    variant_position = np.array(bgen_reader.pos, dtype=int)
-    variant_alleles = np.array(bgen_reader.variant_alleles, dtype="S1")
-    variant_id = np.array(bgen_reader.variant_id, dtype=str)
-
-    sample_id = np.array(bgen_reader.sample_id, dtype=str)
+    variant_position = np.asarray(bgen_reader.pos, dtype=int)
+    variant_alleles = np.asarray(bgen_reader.variant_alleles, dtype="S")
+    variant_id = np.asarray(bgen_reader.variant_id, dtype=str)
+    sample_id = np.asarray(bgen_reader.sample_id, dtype=str)
 
     call_genotype_probability = da.from_array(
         bgen_reader,
@@ -234,3 +237,116 @@ def read_bgen(
     )
 
     return ds
+
+
+def encode_variables(
+    ds: Dataset,
+    compressor: Optional[Any] = zarr.Blosc(cname="zstd", clevel=7, shuffle=2),
+    probability_dtype: Optional[Any] = "uint8",
+) -> Dict[Hashable, Dict[str, Any]]:
+    encoding = {}
+    for v in ds:
+        e = {}
+        if compressor is not None:
+            e.update({"compressor": compressor})
+        if probability_dtype is not None and v == "call_genotype_probability":
+            dtype = np.dtype(probability_dtype)
+            # Xarray will decode into float32 so any int greater than
+            # 16 bits will cause overflow/underflow
+            # See https://en.wikipedia.org/wiki/Floating-point_arithmetic#Internal_representation
+            # *bits precision column for single precision floats
+            if dtype not in [np.uint8, np.uint16]:
+                raise ValueError(
+                    "Probability integer dtype invalid, must "
+                    f"be uint8 or uint16 not {probability_dtype}"
+                )
+            divisor = np.iinfo(dtype).max - 1
+            e.update(
+                {
+                    "dtype": probability_dtype,
+                    "add_offset": -1.0 / divisor,
+                    "scale_factor": 1.0 / divisor,
+                    "_FillValue": 0,
+                }
+            )
+        if e:
+            encoding[v] = e
+    return encoding
+
+
+def pack_variables(ds: Dataset) -> Dataset:
+    # Remove dosage as it is unnecessary and should be redefined
+    # based on encoded probabilities later (w/ reduced precision)
+    ds = ds.drop_vars(["call_dosage", "call_dosage_mask"], errors="ignore")
+
+    # Remove homozygous reference GP and redefine mask
+    gp = ds["call_genotype_probability"][..., 1:]
+    gp_mask = ds["call_genotype_probability_mask"].any(dim="genotypes")
+    ds = ds.drop_vars(["call_genotype_probability", "call_genotype_probability_mask"])
+    ds = ds.assign(call_genotype_probability=gp, call_genotype_probability_mask=gp_mask)
+    return ds
+
+
+def unpack_variables(ds: Dataset, dtype: Any = "float32") -> Dataset:
+    # Restore homozygous reference GP
+    gp = ds["call_genotype_probability"].astype(dtype)
+    if gp.sizes["genotypes"] != 2:
+        raise ValueError(
+            "Expecting variable 'call_genotype_probability' to have genotypes "
+            f"dimension of size 2 (received sizes = {dict(gp.sizes)})"
+        )
+    ds = ds.drop_vars("call_genotype_probability")
+    ds["call_genotype_probability"] = xr.concat(  # type: ignore[no-untyped-call]
+        [1 - gp.sum(dim="genotypes", skipna=False), gp], dim="genotypes"
+    )
+
+    # Restore dosage
+    ds["call_dosage"] = gp[..., 0] + 2 * gp[..., 1]
+    ds["call_dosage_mask"] = ds["call_genotype_probability_mask"]
+    ds["call_genotype_probability_mask"] = ds[
+        "call_genotype_probability_mask"
+    ].broadcast_like(ds["call_genotype_probability"])
+    return ds
+
+
+def rechunk_to_zarr(
+    ds: Dataset,
+    store: Union[PathType, MutableMapping[str, bytes]],
+    *,
+    mode: str = "w",
+    chunk_length: int = 10_000,
+    chunk_width: int = 10_000,
+    compressor: Optional[Any] = zarr.Blosc(cname="zstd", clevel=7, shuffle=2),
+    probability_dtype: Optional[Any] = "uint8",
+    pack: bool = True,
+    compute: bool = True,
+) -> ZarrStore:
+    if pack:
+        ds = pack_variables(ds)
+    for v in set(GT_DATA_VARS) & set(ds):
+        chunk_size = da.asarray(ds[v]).chunksize[0]
+        if chunk_length % chunk_size != 0:
+            raise ValueError(
+                f"Chunk size in variant dimension for variable '{v}' ({chunk_size}) "
+                f"must evenly divide target chunk size {chunk_length}"
+            )
+        ds[v] = ds[v].chunk(chunks=dict(samples=chunk_width))  # type: ignore[dict-item]
+    encoding = encode_variables(
+        ds, compressor=compressor, probability_dtype=probability_dtype
+    )
+    return ds.to_zarr(store, mode=mode, encoding=encoding or None, compute=compute)  # type: ignore[arg-type]
+
+
+def rechunk_from_zarr(
+    store: Union[PathType, MutableMapping[str, bytes]],
+    chunk_length: int = 10_000,
+    chunk_width: int = 10_000,
+    mask_and_scale: bool = True,
+) -> Dataset:
+    # Always use concat_characters=False to avoid https://github.com/pydata/xarray/issues/4405
+    ds = xr.open_zarr(store, mask_and_scale=mask_and_scale, concat_characters=False)  # type: ignore[no-untyped-call]
+    for v in set(GT_DATA_VARS) & set(ds):
+        ds[v] = ds[v].chunk(chunks=dict(variants=chunk_length, samples=chunk_width))
+        # Workaround for https://github.com/pydata/xarray/issues/4380
+        del ds[v].encoding["chunks"]
+    return ds  # type: ignore[no-any-return]

--- a/sgkit_bgen/bgen_reader.py
+++ b/sgkit_bgen/bgen_reader.py
@@ -13,12 +13,13 @@ from bgen_reader._bgen_metafile import bgen_metafile
 from bgen_reader._metafile import create_metafile
 from bgen_reader._reader import infer_metafile_filepath
 from bgen_reader._samples import generate_samples, read_samples_file
-from rechunker import api as rechunker_api
 from xarray import Dataset
 
 from sgkit import create_genotype_dosage_dataset
 from sgkit.typing import ArrayLike, DType
 from sgkit.utils import encode_array
+
+from .rechunker_api import rechunk_dataset  # type: ignore[attr-defined]
 
 PathType = Union[str, Path]
 
@@ -398,7 +399,7 @@ def rechunk_bgen(
     with tempfile.TemporaryDirectory(
         prefix="bgen_to_zarr_", suffix=".zarr", dir=tempdir
     ) as tmpdir:
-        rechunked = rechunker_api.rechunk_dataset(
+        rechunked = rechunk_dataset(
             ds,
             encoding=encoding,
             max_mem=max_mem,

--- a/sgkit_bgen/rechunker_api.py
+++ b/sgkit_bgen/rechunker_api.py
@@ -1,0 +1,83 @@
+# Temporary workaround until https://github.com/pangeo-data/rechunker/pull/52 is in and released
+# type: ignore
+
+import tempfile
+from typing import Mapping, Union
+
+import dask
+import xarray
+import zarr
+from rechunker.api import Rechunked, _get_executor, _setup_array_rechunk
+from rechunker.types import Executor
+from xarray.backends.zarr import (
+    DIMENSION_KEY,
+    encode_zarr_attr_value,
+    encode_zarr_variable,
+    extract_zarr_variable_encoding,
+)
+
+
+def rechunk_dataset(
+    source: xarray.Dataset,
+    encoding: Mapping,
+    max_mem,
+    target_store,
+    temp_store=None,
+    executor: Union[str, Executor] = "dask",
+):
+    def _encode_zarr_attributes(attrs):
+        return {k: encode_zarr_attr_value(v) for k, v in attrs.items()}
+
+    if isinstance(executor, str):
+        executor = _get_executor(executor)
+    if temp_store:
+        temp_group = zarr.group(temp_store)
+    else:
+        temp_group = zarr.group(
+            tempfile.mkdtemp(".zarr", "temp_store_")
+        )  # pragma: no cover
+    target_group = zarr.group(target_store)
+    target_group.attrs.update(_encode_zarr_attributes(source.attrs))
+
+    copy_specs = []
+    for variable in source:
+        array = source[variable].copy()
+
+        # Update the array encoding with provided parameters and apply it
+        has_chunk_encoding = "chunks" in array.encoding
+        array.encoding.update(encoding.get(variable, {}))
+        array = encode_zarr_variable(array)
+
+        # Determine target chunking for array and remove it prior to
+        # validation/extraction ONLY if the array isn't also coming
+        # from a Zarr store (otherwise blocks need to be checked for overlap)
+        target_chunks = array.encoding.get("chunks")
+        if not has_chunk_encoding:
+            array.encoding.pop("chunks", None)
+        array_encoding = extract_zarr_variable_encoding(
+            array, raise_on_invalid=True, name=variable
+        )
+
+        # Default to chunking based on array shape if not explicitly provided
+        default_chunks = array_encoding.pop("chunks")
+        target_chunks = target_chunks or default_chunks
+
+        # Extract array attributes along with reserved property for
+        # xarray dimension names
+        array_attrs = _encode_zarr_attributes(array.attrs)
+        array_attrs[DIMENSION_KEY] = encode_zarr_attr_value(array.dims)
+
+        copy_spec = _setup_array_rechunk(
+            dask.array.asarray(array),
+            target_chunks,
+            max_mem,
+            target_group,
+            target_options=array_encoding,
+            temp_store_or_group=temp_group,
+            temp_options=array_encoding,
+            name=variable,
+        )
+        copy_spec.write.array.attrs.update(array_attrs)  # type: ignore
+        copy_specs.append(copy_spec)
+    plan = executor.prepare_plan(copy_specs)
+    return Rechunked(executor, plan, source, temp_group, target_group)

--- a/sgkit_bgen/tests/data/.gitignore
+++ b/sgkit_bgen/tests/data/.gitignore
@@ -1,0 +1,2 @@
+*.metadata2.mmm
+*.metafile


### PR DESCRIPTION
https://github.com/pystatgen/sgkit-bgen/issues/16

This is a second iteration on https://github.com/pystatgen/sgkit-bgen/pull/21.

Notes:

- The conversion to zarr is done via rechunker instead of through custom code and an intermediate store.
- This expects Xarray integration in rechunker, so it won't really be ready until https://github.com/pangeo-data/rechunker/pull/52 is done.  For now I pointed the build at my fork.
- There are two functions added: `bgen_to_zarr` and `rechunk_bgen`.  I'd expect `bgen_to_zarr` to be less useful than `rechunk_bgen`, but it's there for better consistency with sgkit-vcf.vcf_reader.  The main advantage of working with datasets rather than paths is that it's easier to attach custom sample/variant metadata (as is usually the case w/ plink/bgen) and have it run through the same rechunking flow.
